### PR TITLE
Add a standard build workflow in key4hep

### DIFF
--- a/key4hep-build/action.yml
+++ b/key4hep-build/action.yml
@@ -53,8 +53,6 @@ runs:
           export CPATH=$(echo $CPATH | tr ':' '\n' | grep -v "/$name/" | tr '\n' ':')
           export PYTHONPATH=$(echo $PYTHONPATH | tr ':' '\n' | grep -v "/$name/" | tr '\n' ':')
 
-          echo $LD_LIBRARY_PATH
-
           cmake .. -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=../install -G Ninja
           ninja install
           ctest -j $(nproc) --output-on-failure


### PR DESCRIPTION
This PR is here to discuss the addition of a standard build workflow in key4hep, the changes in this PR are irrelevant.

I propose the addition of a standard build workflow that will be the same for all the repositories in key4hep. The action and workflow files are already in this repository and have the following features:

- Builds for AlmaLinux 9, CentOS 7 and Ubuntu 22.04, also for releases and nightlies, so right now it spawns a total of 6 jobs
- Most of the actual running happens in the action that would be here, meaning that it only would need to be changed in one place (for example changing to C++20)
- It uses images with cvmfs installed which should reduce the time it takes since loading cvmfs is quicker (and the github action only supports ubuntu). Some tests with k4FWCore can do some of the builds in 2-3 minutes but there are builds that take longer.
- Triggers on pushes (so people working on their own forks get it too) and it can also be triggered manually, for example for debugging.
- Removes the current package from the existing environment variables; this should make it work correctly in cases where it could still pick up something old.


The idea is that the current build workflows (only key4hep, not the LCG ones) would be replaced by this one in all the (CMake) repositories. The EDM4hep workflow does some testing of some downstream functionality, so that would have to be discussed.

This is how it will look at the bottom of PRs:

![2023-12-14-183408_851x115_scrot](https://github.com/key4hep/key4hep-actions/assets/22276694/c9da74b8-e48c-4130-8773-b31719cf16dd)

This is how it looks like in the github job tab (the six jobs on the right are initially grouped in one): 

![2023-12-14-183346_1004x520_scrot](https://github.com/key4hep/key4hep-actions/assets/22276694/fdb98eff-816c-4875-8085-bcb4dbf0e39a)

I think it's also a good place to discuss if we want to use the `-Werror` flag to convert warnings to errors since if left uncontrolled it's easy to add them.
