### PR TITLE
Don't stop the build early in case of failures

### DIFF
--- a/key4hep-build/action.yml
+++ b/key4hep-build/action.yml
@@ -77,7 +77,7 @@ runs:
           export PYTHONPATH=$(echo $PYTHONPATH | tr ':' '\n' | grep -v "/$name/" | tr '\n' ':')
 
           cmake .. -DCMAKE_CXX_STANDARD=20 -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_FLAGS="-Werror -Wno-error=cpp -Wno-error=deprecated-declarations" -G Ninja
-          time ninja install
+          time ninja -k0 install
           ctest -j $(nproc) --output-on-failure
           ccache -s
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure to keep building in CI even if there is a failure.

ENDRELEASENOTES

Otherwise fixing errors becomes very incremental, because new errors only show up when previous ones are fixed.