### PR TITLE
Add possibility to pass extra args to ctest

### DIFF
--- a/key4hep-build/action.yml
+++ b/key4hep-build/action.yml
@@ -8,6 +8,11 @@ inputs:
   image:
     description: alma9, ubuntu22
     required: true
+  ctest_extra_args:
+    description: extra arguments to be passed to ctest
+    required: false
+    type: string
+    default: ''
 
 runs:
   using: "composite"
@@ -82,7 +87,7 @@ runs:
 
           cmake .. -DCMAKE_CXX_STANDARD=20 -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_FLAGS="-Werror -Wno-error=cpp -Wno-error=deprecated-declarations" -G Ninja
           time ninja -k0 install
-          ctest -j $(nproc) --output-on-failure
+          ctest -j $(nproc) --output-on-failure ${{ inputs.ctest_extra_args }}
           ccache -s
 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a `ctest_extra_args` input to the `key4hep-build` action to pass extra arguments to ctest.

ENDRELEASENOTES

See https://github.com/key4hep/k4SimDelphes/issues/129 for a rationale