### PR TITLE
Add dependabot config for workflows and actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Keep dependencies for GitHub Actions up-to-date
+  - package-ecosystem: 'github-actions'
+    directory: '/key4hep-build'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'github-actions'
+    directory: '/downstream-build'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'github-actions'
+    directory: '/workflows'
+    schedule:
+      interval: 'weekly'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,11 @@ version: 2
 updates:
   # Keep dependencies for GitHub Actions up-to-date
   - package-ecosystem: 'github-actions'
-    directory: '/key4hep-build'
+    directory: '/downstream-build'
     schedule:
       interval: 'weekly'
   - package-ecosystem: 'github-actions'
-    directory: '/downstream-build'
+    directory: '/key4hep-build'
     schedule:
       interval: 'weekly'
   - package-ecosystem: 'github-actions'

--- a/workflows/auto-commit.yaml
+++ b/workflows/auto-commit.yaml
@@ -16,8 +16,8 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - run: |
@@ -33,5 +33,5 @@ jobs:
           fi
 
       # Commit all changed files back to the repository
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: stefanzweifel/git-auto-commit-action@v5
         if: always()


### PR DESCRIPTION
BEGINRELEASENOTES
- Added dependabot configuration to get updates for github actions
- Updated actions in auto-commit workflow

ENDRELEASENOTES

Configuration for dependabot to periodically scan and update actions.
Each directory with workflows or actions has to be added as a separate entry