### PR TITLE
Add the possibility to inject environment variables and a cmake hook for build action

### DIFF
--- a/key4hep-build/README.md
+++ b/key4hep-build/README.md
@@ -1,0 +1,30 @@
+# `key4hep-build` action
+
+## Action parameters
+
+This action builds the Key4hep stack on supported OSs. It takes two required
+parameters
+
+- `build_type`: Which build are you targetting? Can either be `release`,
+  `nightly` or `other`
+- `image`: Which (OS) image to use, can either be `alma9`, `ubuntu22` or
+  `ubuntu24`
+
+Note that not all combinations of `build_type` and `image` might be available at
+any given point.
+
+Additionally, there is an optional paramter:
+- `stack`: For switching between `key4hep` (default) and `devkey`. **This is a
+  feature for development, so you almost certainly don't need to change this.**
+  
+## Furter customization
+
+In order to allow further customization of the build and its environment it is
+possible to provide an environment file at
+`.github/workflows/.key4hep-build-env` which will be `source`d before the build
+is started. Some environment variables are pre-defined to be pass extra
+arguments to certain build stages
+
+- `K4_CMAKE_EXTRA_ARGS` will be passed (verbatim) to the `cmake` call of the
+  build. Hence, `export K4_CMAKE_EXTRA_ARGS=<your-extra-cmake-args>` in the
+  `.key4hep-build-env` file can be used to alter cmake behavior.

--- a/key4hep-build/README.md
+++ b/key4hep-build/README.md
@@ -17,6 +17,9 @@ Additionally, there is an optional paramter:
 - `stack`: For switching between `key4hep` (default) and `devkey`. **This is a
   feature for development, so you almost certainly don't need to change this.**
   
+The recommended way of running the action is to have scheduled runs at some point in the day
+(for example, after builds for that day have been deployed for nightly builds) because the compilation 
+results will be cached, allowing future PRs to reuse the results and compile much faster.
 ## Furter customization
 
 In order to allow further customization of the build and its environment it is

--- a/key4hep-build/action.yml
+++ b/key4hep-build/action.yml
@@ -98,6 +98,10 @@ runs:
           cd build
 
           if [ -f /${name}/.github/workflows/.key4hep-build-env ]; then
+            echo "Sourcing .keyhep-build-env"
+            echo "----------------------------------"
+            cat /${name}/.github/workflows/.key4hep-build-env
+            echo "----------------------------------"
             source /${name}/.github/workflows/.key4hep-build-env
           fi
 

--- a/key4hep-build/action.yml
+++ b/key4hep-build/action.yml
@@ -12,11 +12,6 @@ inputs:
     description: key4hep or devkey or full path to the setup script
     required: false
     default: key4hep
-  extra_cmake_args:
-    description: "Additional arguments to cmake"
-    required: false
-    type: string
-    default: ''
 
 runs:
   using: "composite"
@@ -102,6 +97,10 @@ runs:
           mkdir build
           cd build
 
+          if [ -f /${name}/.github/workflows/.key4hep-build-env ]; then
+            source /${name}/.github/workflows/.key4hep-build-env
+          fi
+
           export PATH=$(echo $PATH | tr ':' '\n' | grep -v "/$name/" | tr '\n' ':')
           export LD_LIBRARY_PATH=$(echo $LD_LIBRARY_PATH | tr ':' '\n' | grep -v "/$name/" | tr '\n' ':')
           export ROOT_INCLUDE_PATH=$(echo $ROOT_INCLUDE_PATH | tr ':' '\n' | grep -v "/$name/" | tr '\n' ':')
@@ -114,7 +113,7 @@ runs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_FLAGS="-Werror -Wno-error=cpp -Wno-error=deprecated-declarations" \
             -G Ninja \
-            ${{ inputs.extra_cmake_args }}
+            ${K4_EXTRA_CMAKE_ARGS}
           time ninja -k0 install
           ccache -s
 

--- a/key4hep-build/action.yml
+++ b/key4hep-build/action.yml
@@ -12,6 +12,11 @@ inputs:
     description: key4hep or devkey or full path to the setup script
     required: false
     default: key4hep
+  extra_cmake_args:
+    description: "Additional arguments to cmake"
+    required: false
+    type: string
+    default: ''
 
 runs:
   using: "composite"
@@ -103,7 +108,13 @@ runs:
           export CPATH=$(echo $CPATH | tr ':' '\n' | grep -v "/$name/" | tr '\n' ':')
           export PYTHONPATH=$(echo $PYTHONPATH | tr ':' '\n' | grep -v "/$name/" | tr '\n' ':')
 
-          cmake .. -DCMAKE_CXX_STANDARD=20 -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_FLAGS="-Werror -Wno-error=cpp -Wno-error=deprecated-declarations" -G Ninja
+          cmake .. \
+            -DCMAKE_CXX_STANDARD=20 \
+            -DCMAKE_INSTALL_PREFIX=../install \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_FLAGS="-Werror -Wno-error=cpp -Wno-error=deprecated-declarations" \
+            -G Ninja \
+            ${{ inputs.extra_cmake_args }}
           time ninja -k0 install
           ccache -s
 

--- a/key4hep-build/action.yml
+++ b/key4hep-build/action.yml
@@ -91,6 +91,11 @@ runs:
             exit 1
           fi
 
+          function run_cmd() {
+            echo $@
+            $@
+          }
+
           cd /${name}
           # There is no k4_local_repo in the LCG stacks
           k4_local_repo || true
@@ -111,13 +116,14 @@ runs:
           export CPATH=$(echo $CPATH | tr ':' '\n' | grep -v "/$name/" | tr '\n' ':')
           export PYTHONPATH=$(echo $PYTHONPATH | tr ':' '\n' | grep -v "/$name/" | tr '\n' ':')
 
-          cmake .. \
+          run_cmd cmake .. \
             -DCMAKE_CXX_STANDARD=20 \
             -DCMAKE_INSTALL_PREFIX=../install \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_FLAGS="-Werror -Wno-error=cpp -Wno-error=deprecated-declarations" \
             -G Ninja \
             ${K4_CMAKE_EXTRA_ARGS}
+
           time ninja -k0 install
           ccache -s
 

--- a/key4hep-build/action.yml
+++ b/key4hep-build/action.yml
@@ -117,7 +117,7 @@ runs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_FLAGS="-Werror -Wno-error=cpp -Wno-error=deprecated-declarations" \
             -G Ninja \
-            ${K4_EXTRA_CMAKE_ARGS}
+            ${K4_CMAKE_EXTRA_ARGS}
           time ninja -k0 install
           ccache -s
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Add the possibility to alter the environment further via a `.github/workflows/key4hep-build-env` file that is sourced if present in the repository.
- Pass `K4_CMAKE_EXTRA_ARGS` to the `cmake` call.
  - Makes it possible to inject extra cmake args
- Add logging for what is being sourced and also log the final cmake call
  
ENDRELEASENOTES

Would allow to simply pass the necessary arguments to download the STL files on the fly for https://github.com/key4hep/k4geo/pull/428
