### PR TITLE
Remove Ubuntu22 from the builds since podio can not be built with GCC 11

### DIFF
--- a/workflows/key4hep-build.yaml
+++ b/workflows/key4hep-build.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         build_type: ["release", "nightly"]
-        image: ["alma9", "ubuntu22"]
+        image: ["alma9"]
         stack: ["key4hep"]
         include:
           - build_type: nightly


### PR DESCRIPTION
since https://github.com/AIDASoft/podio/pull/620

The last release on Ubuntu 22 doesn't need to be removed as it is not affected but it is pointless to keep it if the nightlies are removed.

I'll update all the workflows soon.