### PR TITLE
include cache-external-data action in dependabot scan

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ version: 2
 updates:
   # Keep dependencies for GitHub Actions up-to-date
   - package-ecosystem: 'github-actions'
+    directory: '/cache-external-data'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'github-actions'
     directory: '/downstream-build'
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
BEGINRELEASENOTES
- Include cache-external-data action in dependabot scan

ENDRELEASENOTES

Just for completeness adding "cache-external-data" action to be included in the dependabot scan just like the rest of actions
