### PR TITLE
Make sure to run command properly in case it contains spaces

### DIFF
--- a/key4hep-build/action.yml
+++ b/key4hep-build/action.yml
@@ -91,11 +91,6 @@ runs:
             exit 1
           fi
 
-          function run_cmd() {
-            echo $@
-            "$@"
-          }
-
           cd /${name}
           # There is no k4_local_repo in the LCG stacks
           k4_local_repo || true
@@ -116,13 +111,15 @@ runs:
           export CPATH=$(echo $CPATH | tr ':' '\n' | grep -v "/$name/" | tr '\n' ':')
           export PYTHONPATH=$(echo $PYTHONPATH | tr ':' '\n' | grep -v "/$name/" | tr '\n' ':')
 
-          run_cmd cmake .. \
+          set -x
+          cmake .. \
             -DCMAKE_CXX_STANDARD=20 \
             -DCMAKE_INSTALL_PREFIX=../install \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_FLAGS="-Werror -Wno-error=cpp -Wno-error=deprecated-declarations" \
             -G Ninja \
             ${K4_CMAKE_EXTRA_ARGS}
+          set +x
 
           time ninja -k0 install
           ccache -s

--- a/key4hep-build/action.yml
+++ b/key4hep-build/action.yml
@@ -89,7 +89,6 @@ runs:
             echo "Unknown build type"
             exit 1
           fi
-          
           mimalloc=$(echo $(dirname $(dirname $(dirname $(dirname $(which mold)))))/mimalloc/*/lib/libmimalloc.so)
           if [ -f "$mimalloc" ]; then
             export LD_PRELOAD=$mimalloc

--- a/key4hep-build/action.yml
+++ b/key4hep-build/action.yml
@@ -93,7 +93,7 @@ runs:
 
           function run_cmd() {
             echo $@
-            $@
+            "$@"
           }
 
           cd /${name}

--- a/key4hep-build/action.yml
+++ b/key4hep-build/action.yml
@@ -89,6 +89,7 @@ runs:
             echo "Unknown build type"
             exit 1
           fi
+
           mimalloc=$(echo $(dirname $(dirname $(dirname $(dirname $(which mold)))))/mimalloc/*/lib/libmimalloc.so)
           if [ -f "$mimalloc" ]; then
             export LD_PRELOAD=$mimalloc


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure to run commands via `run_cmd` properly including quotes and spaces

ENDRELEASENOTES

Otherwise not all `CMAKE_CXX_FLAGS` will be passed properly, see e.g. https://github.com/key4hep/k4FWCore/pull/318 

This version will run the command properly but it will still not display the quotes. For that we would need something like the following

```bash
run_cmd() {
    for arg; do
        # If argument contains spaces or tabs, wrap in double quotes and escape inner double quotes
        if [[ "$arg" =~ [[:space:]] ]]; then
            printf '"%s" ' "${arg//\"/\\\"}"
        else
            printf '%s ' "$arg"
        fi
    done
    echo
    "$@"
}
```