### PR TITLE
Fix the dowstream builds

### DIFF
--- a/downstream-build/action.yml
+++ b/downstream-build/action.yml
@@ -23,6 +23,9 @@ runs:
         git clone https://github.com/spack/spack --single-branch -q
         cd spack
         git checkout $(cat $rel/.spack-commit)
+        # This is not needed since very rarely a new dependency is in the cherry picks
+        # In addition the right commit for key4hep-spack should be used if this is
+        # to be sourced
         # source $rel/.cherry-pick
         cd ..
 


### PR DESCRIPTION
Broken for some time, now this is fixed by not sourcing the cherry picks, which is almost never needed to get the dependents. Now it will run until the end and fail if anything failed on the way. Tested in https://github.com/key4hep/EDM4hep/actions/runs/16903913318/job/47983617539?pr=435#logs except for the last commit