### PR TITLE
Always cache the ccache cache even if builds fail

### DIFF
--- a/key4hep-build/action.yml
+++ b/key4hep-build/action.yml
@@ -19,7 +19,9 @@ runs:
     - shell: bash
       run: echo "NOW=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
-    - uses: actions/cache@v4
+    - name: Restore ccache
+      uses: actions/cache/restore@v4
+      id: ccache-restore
       with:
         path: ~/.cache/ccache
         key: ${{ inputs.build_type }}-${{ inputs.image }}-${{ env.NOW }}
@@ -146,6 +148,13 @@ runs:
           # cat ${GITHUB_WORKSPACE}/script_container.sh
 
           docker exec container /bin/bash -c "/mount.sh && /${name}/script_container.sh"
+
+    - name: Save ccache
+      uses: actions/cache/save@v4
+      if: always()
+      with:
+        path: ~/.cache/ccache
+        key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
 
     - name: Upload EDM4hep file
       if: github.repository == 'key4hep/EDM4hep'

--- a/key4hep-build/action.yml
+++ b/key4hep-build/action.yml
@@ -150,7 +150,7 @@ runs:
           docker exec container /bin/bash -c "/mount.sh && /${name}/script_container.sh"
 
     - name: Save ccache
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       if: always()
       with:
         path: ~/.cache/ccache


### PR DESCRIPTION
This makes sure that the ccache is always stored even if a build or tests fail


BEGINRELEASENOTES
- Store `ccache` cache unconditionally, even if build or tests fail to speed up subsequent runs

ENDRELEASENOTES
