### PR TITLE
Add artifacts for k4GeneratorsConfig

### DIFF
--- a/key4hep-build/action.yml
+++ b/key4hep-build/action.yml
@@ -197,6 +197,7 @@ runs:
       with:
         name: k4GeneratorsConfig_report_${{ matrix.build_type }}_${{ matrix.image }}
         path: |
+          test/xsectionSummary.dat
           test/output/*
         retention-days: 7
         overwrite: true

--- a/key4hep-build/action.yml
+++ b/key4hep-build/action.yml
@@ -191,3 +191,13 @@ runs:
         retention-days: 7
         overwrite: true
 
+    - name: Upload k4Generators file
+      if: github.repository == 'key4hep/k4GeneratorsConfig'
+      uses: actions/upload-artifact@v7
+      with:
+        name: k4GeneratorsConfig_report_${{ matrix.build_type }}_${{ matrix.image }}
+        path: |
+          test/output/*
+        retention-days: 7
+        overwrite: true
+

--- a/key4hep-build/action.yml
+++ b/key4hep-build/action.yml
@@ -197,8 +197,8 @@ runs:
       with:
         name: k4GeneratorsConfig_report_${{ matrix.build_type }}_${{ matrix.image }}
         path: |
-          test/xsectionSummary.dat
-          test/output/*
+          test/Run-Cards/*.dat
+          test/Run-Cards/*.root
         retention-days: 7
         overwrite: true
 


### PR DESCRIPTION
The action can be modified and then the workflow in each repository does not need to change and can still be synced from here and overwritten when there are updates (and changes to the local key4hep_build.yml are lost)

Which files do we put? @dirkzerwas
I copied `test/output` from https://github.com/key4hep/k4GeneratorsConfig/blob/main/.github/workflows/key4hep-build.yaml#L44