### PR TITLE
add missing directory to dependabot, use `directories` directive

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,6 @@ updates:
   - package-ecosystem: 'github-actions'
     directories:
       - '/' # .github/workflows and .yml/.yaml files in the root directory
-      - '/cache-external-data'
-      - '/downstream-build'
-      - '/key4hep-build'
-      - '/workflows'
+      - '/*'
     schedule:
       interval: 'weekly'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,18 +7,11 @@ version: 2
 updates:
   # Keep dependencies for GitHub Actions up-to-date
   - package-ecosystem: 'github-actions'
-    directory: '/cache-external-data'
-    schedule:
-      interval: 'weekly'
-  - package-ecosystem: 'github-actions'
-    directory: '/downstream-build'
-    schedule:
-      interval: 'weekly'
-  - package-ecosystem: 'github-actions'
-    directory: '/key4hep-build'
-    schedule:
-      interval: 'weekly'
-  - package-ecosystem: 'github-actions'
-    directory: '/workflows'
+    directories:
+      - '/' # .github/workflows and .yml/.yaml files in the root directory
+      - '/cache-external-data'
+      - '/downstream-build'
+      - '/key4hep-build'
+      - '/workflows'
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
BEGINRELEASENOTES
- Add `.github/workflows` to dependabot config

ENDRELEASENOTES

Include "./github/workflows"  in the dependabot config so it's scanned too
Also, in meantime support for specifying [multiple directories](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#directories-or-directory--) was added so the config can be simplified. It could probably be simplified further by using wildcards which are now supported too, although I'm reluctant because the directories with actions don't follow any pattern so `/*` would have to be used