### PR TITLE
Upload CTest logs unconditionally

### DIFF
--- a/key4hep-build/action.yml
+++ b/key4hep-build/action.yml
@@ -163,13 +163,12 @@ runs:
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v7
       with:
-        name: CTest logs_${{ inputs.build_type }}_${{ inputs.image }}
+        name: CTest logs_${{ inputs.build_type }}_${{ inputs.image }}_run${{ github.run_id }}_attempt${{ github.run_attempt }}
         path: |
           ${{ github.workspace }}/build/Testing/Temporary
           !${{ github.workspace }}/build/Testing/Temporary/CTestCostData.txt
         if-no-files-found: warn
-        retention-days: 7
-        overwrite: true
+        retention-days: 3
 
     - name: Upload EDM4hep file
       if: github.repository == 'key4hep/EDM4hep'

--- a/key4hep-build/action.yml
+++ b/key4hep-build/action.yml
@@ -159,6 +159,18 @@ runs:
 
           docker exec container /bin/bash -c "/mount.sh && /${name}/script_container.sh"
 
+    - name: Upload CTest logs
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: CTest logs_${{ inputs.build_type }}_${{ inputs.image }}
+        path: |
+          ${{ github.workspace }}/build/Testing/Temporary
+          !${{ github.workspace }}/build/Testing/Temporary/CTestCostData.txt
+        if-no-files-found: warn
+        retention-days: 7
+        overwrite: true
+
     - name: Upload EDM4hep file
       if: github.repository == 'key4hep/EDM4hep'
       uses: actions/upload-artifact@v7


### PR DESCRIPTION
Close #40
This will only keep the latest log for a given job, we could keep all of them but then the retention period has to be reduced and I would like if it does not make caches to be evicted because 500 MB is the maximum size and some repos have humongous logs.