### PR TITLE
[do-not-merge] Remove parallel execution from ctest command

### DIFF
--- a/key4hep-build/action.yml
+++ b/key4hep-build/action.yml
@@ -148,7 +148,7 @@ runs:
             export PYTHONPATH=/${name}/install/lib/python*/site-packages:/${name}/install/python:$PYTHONPATH
           fi
 
-          ctest -j $(nproc) --output-on-failure
+          ctest --output-on-failure
 
 
           EOF


### PR DESCRIPTION
BEGINRELEASENOTES
- Thank you for writing the text to appear in the release notes. It will show up
  exactly as it appears between the two bold lines
- ...

ENDRELEASENOTES

For checking whether parallel execution is the issue in https://github.com/key4hep/k4geo/pull/557